### PR TITLE
Add ignore for DocFX configuration #5

### DIFF
--- a/doc/docfx.json
+++ b/doc/docfx.json
@@ -8,6 +8,7 @@
           ],
           "exclude": [
             "**/*.Test*/**",
+            "**/*.Templates*/**",
             "**/obj/**",
             "**/bin/**",
             "_site/**"

--- a/doc/index.md
+++ b/doc/index.md
@@ -11,6 +11,6 @@ It contains the most important information to get started with, and understandin
 [1]: https://ci.appveyor.com/api/projects/status/xs9789ye8ulu29j3/branch/citychain?svg=true
 [2]: https://ci.appveyor.com/project/citychain/city-chain
 
-[Get started here](/articles/intro.html)
+[Get started here](/spec/intro.html)
 
 [Source Code](https://github.com/CityChainFoundation/city-chain)


### PR DESCRIPTION
- The new template projects require Visual Studio plugin, not available on AppVeyor. Needs to be ignored for build to work.