### PR TITLE
Attempt to remove runtime framework version from daemons

### DIFF
--- a/src/City.Chain.DNS/City.Chain.DNS.csproj
+++ b/src/City.Chain.DNS/City.Chain.DNS.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>City.Chain.DNS</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>City.Chain.DNS</PackageId>
-    <RuntimeFrameworkVersion>2.1.1</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/src/City.Chain/City.Chain.csproj
+++ b/src/City.Chain/City.Chain.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>City.Chain</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>City.Chain</PackageId>
-    <RuntimeFrameworkVersion>2.1.1</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>


### PR DESCRIPTION
- Problems building the City Hub with these, as the SimpleWallet builds against 2.1.2.