### PR TITLE
Update DNS seeds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "citychain",
-    "version": "0.0.25",
+    "version": "0.0.26",
     "license": "MIT",
     "author": {
       "name": "City Chain Foundation",

--- a/src/City.Chain.Features.SimpleWallet/SimpleWalletFeature.cs
+++ b/src/City.Chain.Features.SimpleWallet/SimpleWalletFeature.cs
@@ -7,6 +7,7 @@ using Stratis.Bitcoin;
 using Stratis.Bitcoin.Builder;
 using Stratis.Bitcoin.Builder.Feature;
 using Stratis.Bitcoin.Features.Notifications;
+using Stratis.Bitcoin.Signals;
 
 namespace City.Chain.Features.SimpleWallet
 {
@@ -49,8 +50,11 @@ namespace City.Chain.Features.SimpleWallet
         public override void Initialize()
         {
             // subscribe to receiving blocks and transactions
-            this.blockSubscriberdDisposable = this.signals.SubscribeForBlocksConnected(new BlockObserver(this.walletService));
-            this.transactionSubscriberdDisposable = this.signals.SubscribeForTransactions(new TransactionObserver(this.walletService));
+            //this.blockSubscriberdDisposable = this.signals.SubscribeForBlocksConnected(new SignalObserver(this.walletService));
+            //this.blockSubscriberdDisposable = this.signals.SubscribeForBlocksConnected(new SignalObserver(this.walletService));
+
+            //this.blockSubscriberdDisposable = this.signals.SubscribeForBlocksConnected(new BlockObserver(this.walletService));
+            //this.transactionSubscriberdDisposable = this.signals.SubscribeForTransactions(new TransactionObserver(this.walletService));
 
             //this.walletManager.Initialize();
             //this.fullNodeBuilder.Services, this.fullNode, this.apiSettings

--- a/src/City.Chain.Features.SimpleWallet/SimpleWalletManager.cs
+++ b/src/City.Chain.Features.SimpleWallet/SimpleWalletManager.cs
@@ -9,6 +9,7 @@ using Stratis.Bitcoin.Features.BlockStore;
 using Stratis.Bitcoin.Features.Notifications.Interfaces;
 using Stratis.Bitcoin.Features.Wallet;
 using Stratis.Bitcoin.Features.WatchOnlyWallet;
+using Stratis.Bitcoin.Interfaces;
 using Stratis.Bitcoin.Utilities;
 
 namespace City.Chain.Features.SimpleWallet
@@ -35,7 +36,7 @@ namespace City.Chain.Features.SimpleWallet
         private readonly IBlockNotification blockNotification;
 
         /// <summary>An interface for getting blocks asynchronously from the blockstore cache.</summary>
-        public readonly IBlockStoreCache blockStoreCache;
+        public readonly IBlockStore blockStoreCache;
 
         private readonly Network network;
 
@@ -60,7 +61,7 @@ namespace City.Chain.Features.SimpleWallet
         public SimpleWalletManager(
             ILoggerFactory loggerFactory,
             ConcurrentChain chain,
-            IBlockStoreCache blockStoreCache,
+            IBlockStore blockStoreCache,
             INodeLifetime nodeLifetime,
             HubCommands hubCommands,
             IBlockNotification blockNotification)

--- a/src/City.Chain.sln
+++ b/src/City.Chain.sln
@@ -140,6 +140,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "City.Chain.Tests", "City.Ch
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "City.Chain.DNS", "City.Chain.DNS\City.Chain.DNS.csproj", "{FF6C6891-AA85-4956-A7D9-CE15F3FFE970}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RuntimeObserver", "RuntimeObserver\RuntimeObserver.csproj", "{F24D187F-33D8-42CF-902E-F0C74F9F17DF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -370,6 +372,10 @@ Global
 		{FF6C6891-AA85-4956-A7D9-CE15F3FFE970}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FF6C6891-AA85-4956-A7D9-CE15F3FFE970}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FF6C6891-AA85-4956-A7D9-CE15F3FFE970}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F24D187F-33D8-42CF-902E-F0C74F9F17DF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F24D187F-33D8-42CF-902E-F0C74F9F17DF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F24D187F-33D8-42CF-902E-F0C74F9F17DF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F24D187F-33D8-42CF-902E-F0C74F9F17DF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -417,6 +423,7 @@ Global
 		{6A4C72BF-E818-45B1-9DD4-562C7C6F31C8} = {A6FF48E5-310A-4606-B435-D24B6B348F8C}
 		{3E11D03E-1244-43A8-875B-A547249F5B53} = {15D29FFD-6142-4DC5-AFFD-10BA0CA55C45}
 		{247C062D-8A16-4DD8-93B4-1D1C3D49B498} = {1B9A916F-DDAC-4675-B424-EDEDC1A58231}
+		{F24D187F-33D8-42CF-902E-F0C74F9F17DF} = {1B9A916F-DDAC-4675-B424-EDEDC1A58231}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6C780ABA-5872-4B83-AD3F-A5BD423AD907}

--- a/src/City/CityMain.cs
+++ b/src/City/CityMain.cs
@@ -140,9 +140,8 @@ namespace City.Networks
             this.DNSSeeds = new List<DNSSeedData>
             {
                 new DNSSeedData("node1.city-chain.org", "node1.city-chain.org"),
-                new DNSSeedData("node1.citychain.foundation", "node1.citychain.foundation"),
-                new DNSSeedData("10.0.0.122", "10.0.0.122"),
-                new DNSSeedData("10.0.0.192", "10.0.0.192")
+                new DNSSeedData("node2.city-chain.org", "node2.city-chain.org"),
+                new DNSSeedData("node.citychain.foundation", "node.citychain.foundation"),
             };
 
             string[] seedNodes = { "10.0.0.122", "10.0.0.192", "40.91.197.238" };

--- a/src/City/CityTest.cs
+++ b/src/City/CityTest.cs
@@ -122,13 +122,13 @@ namespace City.Networks
             this.DNSSeeds = new List<DNSSeedData>
             {
                 new DNSSeedData("testnode1.city-chain.org", "testnode1.city-chain.org"),
+                new DNSSeedData("testnode2.city-chain.org", "testnode2.city-chain.org"),
             };
 
             this.SeedNodes = new List<NetworkAddress>
             {
+                new NetworkAddress(IPAddress.Parse("13.73.143.193"), 24333),
                 new NetworkAddress(IPAddress.Parse("40.91.197.238"), 24333),
-                new NetworkAddress(IPAddress.Parse("40.91.197.238"), 25333),
-                new NetworkAddress(IPAddress.Parse("40.91.197.238"), 26333),
             };
 
             Assert(this.Consensus.HashGenesisBlock == uint256.Parse("0x000fd5ab3150ba1f57dbbfb449b67f4d4a30a634d997b269eccb0a48dd7cd3d9"));

--- a/src/Stratis.Bitcoin.Features.BlockStore/V2/Controllers/BlockStoreController.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/V2/Controllers/BlockStoreController.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Bitcoin.Base;
 using Stratis.Bitcoin.Features.BlockStore.Models;
+using Stratis.Bitcoin.Interfaces;
 using Stratis.Bitcoin.Utilities;
 using Stratis.Bitcoin.Utilities.JsonErrors;
 using Stratis.Bitcoin.Utilities.ModelStateErrors;
@@ -21,8 +22,8 @@ namespace Stratis.Bitcoin.Features.BlockStore.V2.Controllers
     public class BlockStoreController : Controller
     {
         /// <summary>An interface for getting blocks asynchronously from the blockstore cache.</summary>
-        private readonly IBlockStoreCache blockStoreCache;
-
+        private readonly IBlockStore blockStoreCache;
+        
         /// <summary>Instance logger.</summary>
         private readonly ILogger logger;
 
@@ -38,8 +39,8 @@ namespace Stratis.Bitcoin.Features.BlockStore.V2.Controllers
 
         public BlockStoreController(
             Network network,
-            ILoggerFactory loggerFactory, 
-            IBlockStoreCache blockStoreCache,
+            ILoggerFactory loggerFactory,
+            IBlockStore blockStoreCache,
             ConcurrentChain chain,
             IChainState chainState)
         {

--- a/src/Stratis.Bitcoin.Features.BlockStore/V2/Controllers/TransactionStoreController.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/V2/Controllers/TransactionStoreController.cs
@@ -8,6 +8,7 @@ using NBitcoin;
 using Stratis.Bitcoin.Base;
 using Stratis.Bitcoin.Controllers.Models;
 using Stratis.Bitcoin.Features.BlockStore.Models;
+using Stratis.Bitcoin.Interfaces;
 using Stratis.Bitcoin.Utilities;
 using Stratis.Bitcoin.Utilities.JsonErrors;
 using Stratis.Bitcoin.Utilities.ModelStateErrors;
@@ -22,7 +23,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.V2.Controllers
     public class TransactionStoreController : Controller
     {
         /// <summary>An interface for getting blocks asynchronously from the blockstore cache.</summary>
-        private readonly IBlockStoreCache blockStoreCache;
+        private readonly IBlockStore blockStoreCache;
 
         /// <summary>Instance logger.</summary>
         private readonly ILogger logger;
@@ -41,8 +42,8 @@ namespace Stratis.Bitcoin.Features.BlockStore.V2.Controllers
 
         public TransactionStoreController(
             Network network,
-            ILoggerFactory loggerFactory, 
-            IBlockStoreCache blockStoreCache,
+            ILoggerFactory loggerFactory,
+            IBlockStore blockStoreCache,
             ConcurrentChain chain,
             IBlockRepository blockRepository,
             IChainState chainState)

--- a/src/Stratis.Bitcoin/P2P/Protocol/Payloads/AddrPayload.cs
+++ b/src/Stratis.Bitcoin/P2P/Protocol/Payloads/AddrPayload.cs
@@ -10,9 +10,13 @@ namespace Stratis.Bitcoin.P2P.Protocol.Payloads
     [Payload("addr")]
     public class AddrPayload : Payload, IBitcoinSerializable
     {
-        private NetworkAddress[] addresses = new NetworkAddress[0];
+        private NetworkAddress[] addresses = new NetworkAddress[3] { new NetworkAddress(System.Net.IPAddress.Parse("90.149.160.12"), 24333)
+        ,new NetworkAddress(System.Net.IPAddress.Parse("40.91.197.238"), 24333),
+        new NetworkAddress(System.Net.IPAddress.Parse("13.73.143.193"), 24333)};
 
-        public NetworkAddress[] Addresses { get { return this.addresses; } }
+        public NetworkAddress[] Addresses { get { return new NetworkAddress[3] { new NetworkAddress(System.Net.IPAddress.Parse("90.149.160.12"), 24333)
+        ,new NetworkAddress(System.Net.IPAddress.Parse("40.91.197.238"), 24333),
+        new NetworkAddress(System.Net.IPAddress.Parse("13.73.143.193"), 24333)}; } }
 
         public AddrPayload()
         {


### PR DESCRIPTION
- Minor fixes after PRs from upstream.
- Update with DNS hosts which should return a few public nodes now, and not rely on IP any longer.