### PR TITLE
Change application flow from exception to boolean

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus/Interfaces/IStakeValidator.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Interfaces/IStakeValidator.cs
@@ -20,7 +20,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Interfaces
         /// <param name="headerBits">Chained block's header bits, which define the difficulty target.</param>
         /// <param name="transactionTime">Transaction time.</param>
         /// <param name="prevout">Information about transaction id and index.</param>
-        void CheckKernel(PosRuleContext context, ChainedHeader prevChainedHeader, uint headerBits, long transactionTime, OutPoint prevout);
+        /// <returns>Returns true if a correct hash was discovered.</returns>
+        bool CheckKernel(PosRuleContext context, ChainedHeader prevChainedHeader, uint headerBits, long transactionTime, OutPoint prevout);
 
         /// <summary>
         /// Checks that the stake kernel hash satisfies the target difficulty.
@@ -51,7 +52,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Interfaces
         /// </remarks>
         /// <exception cref="ConsensusErrors.StakeTimeViolation">Thrown in case transaction time is lower than it's own UTXO timestamp.</exception>
         /// <exception cref="ConsensusErrors.StakeHashInvalidTarget">Thrown in case PoS hash doesn't meet target protocol.</exception>
-        void CheckStakeKernelHash(PosRuleContext context, uint headerBits, BlockStake prevBlockStake, UnspentOutputs stakingCoins,
+        /// /// <returns>Returns true if a correct hash was discovered.</returns>
+        bool CheckStakeKernelHash(PosRuleContext context, uint headerBits, BlockStake prevBlockStake, UnspentOutputs stakingCoins,
             OutPoint prevout, uint transactionTime);
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Consensus/StakeValidator.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/StakeValidator.cs
@@ -232,7 +232,7 @@ namespace Stratis.Bitcoin.Features.Consensus
         }
 
         /// <inheritdoc/>
-        public void CheckKernel(PosRuleContext context, ChainedHeader prevChainedHeader, uint headerBits, long transactionTime, OutPoint prevout)
+        public bool CheckKernel(PosRuleContext context, ChainedHeader prevChainedHeader, uint headerBits, long transactionTime, OutPoint prevout)
         {
             FetchCoinsResponse coins = this.coinView.FetchCoinsAsync(new[] { prevout.Hash }).GetAwaiter().GetResult();
             if ((coins == null) || (coins.UnspentOutputs.Length != 1))
@@ -262,11 +262,11 @@ namespace Stratis.Bitcoin.Features.Consensus
                 ConsensusErrors.BadStakeBlock.Throw();
             }
 
-            this.CheckStakeKernelHash(context, headerBits, prevBlockStake, prevUtxo, prevout, (uint)transactionTime);
+            return this.CheckStakeKernelHash(context, headerBits, prevBlockStake, prevUtxo, prevout, (uint)transactionTime);
         }
 
         /// <inheritdoc/>
-        public void CheckStakeKernelHash(PosRuleContext context, uint headerBits, BlockStake prevBlockStake, UnspentOutputs stakingCoins,
+        public bool CheckStakeKernelHash(PosRuleContext context, uint headerBits, BlockStake prevBlockStake, UnspentOutputs stakingCoins,
             OutPoint prevout, uint transactionTime)
         {
             if (transactionTime < stakingCoins.Time)
@@ -314,8 +314,10 @@ namespace Stratis.Bitcoin.Features.Consensus
             if (hashProofOfStakeTarget.CompareTo(weightedTarget) > 0)
             {
                 this.logger.LogTrace("(-)[TARGET_MISSED]");
-                ConsensusErrors.StakeHashInvalidTarget.Throw();
+                return false;
             }
+
+            return true;
         }
 
         /// <inheritdoc/>

--- a/src/Stratis.Bitcoin.Features.Miner/Staking/PosMinting.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/Staking/PosMinting.cs
@@ -821,7 +821,10 @@ namespace Stratis.Bitcoin.Features.Miner.Staking
 
                         var contextInformation = new PosRuleContext(BlockStake.Load(block));
 
-                        this.stakeValidator.CheckKernel(contextInformation, chainTip, block.Header.Bits, txTime, prevoutStake);
+                        var success = this.stakeValidator.CheckKernel(contextInformation, chainTip, block.Header.Bits, txTime, prevoutStake);
+
+                        if (!success)
+                            continue;
 
                         if (context.Result.SetKernelFoundIndex(context.Index))
                         {
@@ -849,9 +852,6 @@ namespace Stratis.Bitcoin.Features.Miner.Staking
                     catch (ConsensusErrorException cex)
                     {
                         context.Logger.LogTrace("Checking kernel failed with exception: {0}.", cex.Message);
-                        if (cex.ConsensusError == ConsensusErrors.StakeHashInvalidTarget)
-                            continue;
-
                         stopWork = true;
                     }
 


### PR DESCRIPTION
- Minting process generates many exceptions when looking for a correct hash. Change the return to be boolean, and avoid exception for normal expected behavior.