### PR TITLE
Allow the reset API action to sync after initial delete

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "citychain",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "license": "MIT",
     "author": {
       "name": "City Chain Foundation",

--- a/src/City/City.csproj
+++ b/src/City/City.csproj
@@ -13,6 +13,7 @@
     <ProjectReference Include="..\NBitcoin\NBitcoin.csproj" />
     <ProjectReference Include="..\Stratis.Bitcoin.Features.BlockStore\Stratis.Bitcoin.Features.BlockStore.csproj" />
     <ProjectReference Include="..\Stratis.Bitcoin.Features.Consensus\Stratis.Bitcoin.Features.Consensus.csproj" />
+    <ProjectReference Include="..\Stratis.Bitcoin.Features.Wallet\Stratis.Bitcoin.Features.Wallet.csproj" />
     <ProjectReference Include="..\Stratis.Bitcoin\Stratis.Bitcoin.csproj" />
   </ItemGroup>
 

--- a/src/City/Models/BroadcastTransactionModel.cs.cs
+++ b/src/City/Models/BroadcastTransactionModel.cs.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Stratis.Bitcoin.Features.Wallet.Models;
+
+namespace City.Models
+{
+    public class BroadcastTransactionModel : RequestModel
+    {
+    }
+}

--- a/src/City/Networks/CityMain.cs
+++ b/src/City/Networks/CityMain.cs
@@ -141,6 +141,7 @@ namespace City.Networks
 
             this.SeedNodes = new List<NetworkAddress>
             {
+                new NetworkAddress(IPAddress.Parse("52.175.194.227"), this.DefaultPort),
                 new NetworkAddress(IPAddress.Parse("13.73.143.193"), this.DefaultPort),
                 new NetworkAddress(IPAddress.Parse("40.115.2.6"), this.DefaultPort),
                 new NetworkAddress(IPAddress.Parse("13.66.158.6"), this.DefaultPort),

--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -1031,14 +1031,24 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
                 }
 
                 // If the user chose to resync the wallet after removing transactions.
-                if (result.Any() && request.ReSync)
+                if (request.ReSync)
                 {
-                    // From the list of removed transactions, check which one is the oldest and retrieve the block right before that time.
-                    DateTimeOffset earliestDate = result.Min(r => r.creationTime);
-                    ChainedHeader chainedHeader = this.chain.GetBlock(this.chain.GetHeightAtTime(earliestDate.DateTime));
-
                     // Update the wallet and save it to the file system.
                     Wallet wallet = this.walletManager.GetWallet(request.WalletName);
+
+                    DateTimeOffset earliestDate;
+
+                    if (result.Any())
+                    {
+                        // From the list of removed transactions, check which one is the oldest and retrieve the block right before that time.
+                        earliestDate = result.Min(r => r.creationTime);
+                    }
+                    else {
+                        earliestDate = wallet.CreationTime;
+                    }
+                    
+                    ChainedHeader chainedHeader = this.chain.GetBlock(this.chain.GetHeightAtTime(earliestDate.DateTime));
+
                     wallet.SetLastBlockDetailsByCoinType(this.coinType, chainedHeader);
                     this.walletManager.SaveWallet(wallet);
 


### PR DESCRIPTION
- If the reset API method is called without resync, it was impossible to start sync with the same method call.