### PR TITLE
RPC add method listsinceblock,getunusedaddress and change getnewaddress

### DIFF
--- a/src/Stratis.Bitcoin.Features.RPC.Tests/Controller/WalletRPCControllerTests.cs
+++ b/src/Stratis.Bitcoin.Features.RPC.Tests/Controller/WalletRPCControllerTests.cs
@@ -1,0 +1,100 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Moq;
+using NBitcoin;
+using Stratis.Bitcoin.Configuration;
+using Stratis.Bitcoin.Consensus;
+using Stratis.Bitcoin.Controllers.Models;
+using Stratis.Bitcoin.Features.BlockStore;
+using Stratis.Bitcoin.Features.RPC.Controllers;
+using Stratis.Bitcoin.Features.RPC.Exceptions;
+using Stratis.Bitcoin.Features.Wallet;
+using Stratis.Bitcoin.Features.Wallet.Interfaces;
+using Stratis.Bitcoin.Features.Wallet.Models;
+using Stratis.Bitcoin.Interfaces;
+using Stratis.Bitcoin.Tests.Common;
+using Stratis.Bitcoin.Tests.Common.Logging;
+using Xunit;
+
+namespace Stratis.Bitcoin.Features.RPC.Tests.Controller
+{
+    public class WalletRPCControllerTests : LogsTestBase
+    {
+        private WalletRPCController controller;
+        private ChainIndexer chain;
+        private Network network;
+        private NodeSettings nodeSettings;
+        private WalletSettings walletSettings;
+        private readonly StoreSettings storeSettings;
+        private readonly List<ActionDescriptor> descriptors;
+
+        private readonly Mock<IBlockStore> blockStore;
+        private readonly Mock<IBroadcasterManager> broadCastManager;
+        private readonly Mock<IConsensusManager> consensusManager;
+        private readonly Mock<IFullNode> fullNode;
+        private readonly Mock<IScriptAddressReader> scriptAddressReader;
+        private readonly Mock<IWalletManager> walletManager;
+        private readonly Mock<IWalletTransactionHandler> walletTransactionHandler;
+
+        public WalletRPCControllerTests()
+        {
+            this.network = KnownNetworks.TestNet;
+            this.blockStore = new Mock<IBlockStore>();
+            this.broadCastManager = new Mock<IBroadcasterManager>();
+            this.consensusManager = new Mock<IConsensusManager>();
+            this.fullNode = new Mock<IFullNode>();
+            this.scriptAddressReader = new Mock<IScriptAddressReader>();
+            this.nodeSettings = new NodeSettings(this.Network);
+            this.storeSettings = new StoreSettings(this.nodeSettings);
+            this.walletManager = new Mock<IWalletManager>();
+            this.walletSettings = new WalletSettings(this.nodeSettings);
+            this.walletTransactionHandler = new Mock<IWalletTransactionHandler>();
+
+            this.controller = 
+                new WalletRPCController(
+                        this.blockStore.Object, 
+                        this.broadCastManager.Object, 
+                        this.chain, 
+                        this.consensusManager.Object, 
+                        this.fullNode.Object, 
+                        this.LoggerFactory.Object,
+                        this.network, 
+                        this.scriptAddressReader.Object,
+                        this.storeSettings,
+                        this.walletManager.Object,
+                        this.walletSettings,
+                        this.walletTransactionHandler.Object
+                        );
+        }
+
+        [Fact]
+        public void GetNewAddress_WithAccountParameterSet_ThrowsException()
+        {
+            RPCServerException exception = Assert.Throws<RPCServerException>(() =>
+            {
+                NewAddressModel result = this.controller.GetNewAddress("test");
+            });
+
+            Assert.NotNull(exception);
+            Assert.Equal("Use of 'account' parameter has been deprecated", exception.Message);
+        }
+
+        [Fact]
+        public void GetNewAddress_WithIncompatibleAddressType_ThrowsException()
+        {
+            RPCServerException exception = Assert.Throws<RPCServerException>(() =>
+            {
+                NewAddressModel result = this.controller.GetNewAddress("", "x");
+            });
+
+            Assert.NotNull(exception);
+            Assert.Equal("Only address type 'legacy' is currently supported.", exception.Message);
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.RPC.Tests/Controller/WalletRPCControllerTests.cs
+++ b/src/Stratis.Bitcoin.Features.RPC.Tests/Controller/WalletRPCControllerTests.cs
@@ -96,5 +96,29 @@ namespace Stratis.Bitcoin.Features.RPC.Tests.Controller
             Assert.NotNull(exception);
             Assert.Equal("Only address type 'legacy' is currently supported.", exception.Message);
         }
+
+        [Fact]
+        public void GetUnusedAddress_WithAccountParameterSet_ThrowsException()
+        {
+            RPCServerException exception = Assert.Throws<RPCServerException>(() =>
+            {
+                NewAddressModel result = this.controller.GetUnusedAddress("test", "");
+            });
+
+            Assert.NotNull(exception);
+            Assert.Equal("Use of 'account' parameter has been deprecated", exception.Message);
+        }
+
+        [Fact]
+        public void GetUnusedAddress_WithIncompatibleAddressType_ThrowsException()
+        {
+            RPCServerException exception = Assert.Throws<RPCServerException>(() =>
+            {
+                NewAddressModel result = this.controller.GetUnusedAddress("", "x");
+            });
+
+            Assert.NotNull(exception);
+            Assert.Equal("Only address type 'legacy' is currently supported.", exception.Message);
+        }
     }
 }

--- a/src/Stratis.Bitcoin.Features.RPC/RPCOperations.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RPCOperations.cs
@@ -29,6 +29,7 @@
         estimatefee,
 
         getnewaddress,
+        getunusedaddress,
         getaccountaddress,
         getrawchangeaddress,
         setaccount,

--- a/src/Stratis.Bitcoin.Features.RPC/RPCParametersValueProvider.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RPCParametersValueProvider.cs
@@ -75,6 +75,10 @@ namespace Stratis.Bitcoin.Features.RPC
 
             int index = this.context.ActionContext.ActionDescriptor.Parameters.IndexOf(parameter);
             var parameters = (JArray)req["params"];
+
+            if (parameters == null)
+                return null;
+
             if ((index < 0) || (index >= parameters.Count))
                 return null;
 

--- a/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
@@ -182,8 +182,9 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         /// <param name="accountReference">The name of the wallet and account.</param>
         /// <param name="count">The number of addresses to create.</param>
         /// <param name="isChange">A value indicating whether or not the addresses to get should be receiving or change addresses.</param>
+        /// <param name="alwaysnew">A value indicating whether or not the address to get should be a new or unused address.</param>
         /// <returns>A list of unused addresses. New addresses will be created as necessary.</returns>
-        IEnumerable<HdAddress> GetUnusedAddresses(WalletAccountReference accountReference, int count, bool isChange = false);
+        IEnumerable<HdAddress> GetUnusedAddresses(WalletAccountReference accountReference, int count, bool isChange = false, bool alwaysnew = false);
 
         /// <summary>
         /// Gets the history of transactions contained in an account.

--- a/src/Stratis.Bitcoin.Features.Wallet/Models/ListSinceBlockModel.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Models/ListSinceBlockModel.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using NBitcoin;
+using Newtonsoft.Json;
+using Stratis.Bitcoin.Utilities.JsonConverters;
+
+namespace Stratis.Bitcoin.Features.Wallet.Models
+{
+    public class ListSinceBlockModel
+    {
+        [JsonProperty("transactions")]
+        public IList<ListSinceBlockTransactionModel> Transactions { get; } = new List<ListSinceBlockTransactionModel>();
+
+        [JsonProperty("lastblock", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(UInt256JsonConverter))]
+        public uint256 LastBlock { get; set; }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Wallet/Models/ListSinceBlockTransactionModel.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Models/ListSinceBlockTransactionModel.cs
@@ -1,0 +1,127 @@
+﻿using System.Runtime.Serialization;
+using NBitcoin;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Stratis.Bitcoin.Utilities.JsonConverters;
+
+namespace Stratis.Bitcoin.Features.Wallet.Models
+{
+    public class ListSinceBlockTransactionModel
+    {
+        /// <summary>
+        /// The account for the transaction
+        /// </summary>
+        [JsonProperty("account")]
+        public string Account { get; set; } = "";
+
+        /// <summary>
+        /// The address involved in the transaction.
+        /// For 'send' it's the external destination address it was sent to, for 'receive' it's the wallet address it was received into.
+        /// </summary>
+        [JsonProperty("address")]
+        public string Address { get; set; }
+
+        /// <summary>
+        /// The transaction category.
+        /// </summary>
+        [JsonProperty("category")]
+        public ListSinceBlockTransactionCategoryModel Category { get; set; }
+
+        /// <summary>
+        /// The total amount received or spent in this transaction.
+        /// Can be positive (received), negative (sent) or 0 (payment to yourself).
+        /// </summary>
+        [JsonProperty(PropertyName = "amount")]
+        public decimal Amount { get; set; }
+
+        /// <summary>
+        /// The index of the output being sent or received.
+        /// </summary>
+        [JsonProperty("vout", NullValueHandling = NullValueHandling.Ignore)]
+        public int? OutputIndex { get; set; }
+
+        /// <summary>
+        /// The amount of the fee. This is negative and only available for the 'send' category of transactions.
+        /// </summary>
+        [JsonProperty("fee", NullValueHandling = NullValueHandling.Ignore)]
+        public decimal? Fee { get; set; }
+
+        /// <summary>
+        /// The number of confirmations.
+        /// </summary>
+        [JsonProperty("confirmations", NullValueHandling = NullValueHandling.Ignore)]
+        public int Confirmations { get; set; }
+
+        /// <summary>
+        /// The block hash.
+        /// </summary>
+        [JsonProperty("blockhash", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(UInt256JsonConverter))]
+        public uint256 BlockHash { get; set; }
+
+        /// <summary>
+        /// The index of the transaction in the block that includes it.
+        /// </summary>
+        [JsonProperty("blockindex", NullValueHandling = NullValueHandling.Ignore)]
+        public int? BlockIndex { get; set; }
+
+        /// <summary>
+        /// The time in seconds since epoch (1 Jan 1970 GMT).
+        /// </summary>
+        [JsonProperty(PropertyName = "blocktime", NullValueHandling = NullValueHandling.Ignore)]
+        public long? BlockTime { get; set; }
+
+        /// <summary>
+        /// The transaction id.
+        /// </summary>
+        [JsonProperty("txid")]
+        [JsonConverter(typeof(UInt256JsonConverter))]
+        public uint256 TransactionId { get; set; }
+
+        /// <summary>
+        /// The transaction time in seconds since epoch (1 Jan 1970 GMT).
+        /// </summary>
+        [JsonProperty("time")]
+        public long TransactionTime { get; set; }
+
+        /// <summary>
+        /// The time received in seconds since epoch (1 Jan 1970 GMT).
+        /// </summary>
+        [JsonProperty(PropertyName = "timereceived")]
+        public long TimeReceived { get; set; }
+    }
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum ListSinceBlockTransactionCategoryModel
+    {
+        /// <summary>
+        /// Non-coinbase transactions received.
+        /// </summary>
+        [EnumMember(Value = "receive")]
+        Receive,
+
+        /// <summary>
+        /// Transactions sent.
+        /// </summary>
+        [EnumMember(Value = "send")]
+        Send,
+
+        /// <summary>
+        /// Mature coinbase or coinstake transactions.
+        /// </summary>
+        [EnumMember(Value = "generate")]
+        Generate,
+
+        /// <summary>
+        /// Immature coinbase or coinstake transactions.
+        /// </summary>
+        [EnumMember(Value = "immature")]
+        Immature,
+
+        /// <summary>
+        /// Orphaned coinbase or coinstake transactions received.
+        /// </summary>
+        [EnumMember(Value = "orphan")]
+        Orphan
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Wallet/Models/ListSinceBlockTransactionModel.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Models/ListSinceBlockTransactionModel.cs
@@ -35,12 +35,6 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
         public decimal Amount { get; set; }
 
         /// <summary>
-        /// The index of the output being sent or received.
-        /// </summary>
-        [JsonProperty("vout", NullValueHandling = NullValueHandling.Ignore)]
-        public int? OutputIndex { get; set; }
-
-        /// <summary>
         /// The amount of the fee. This is negative and only available for the 'send' category of transactions.
         /// </summary>
         [JsonProperty("fee", NullValueHandling = NullValueHandling.Ignore)]

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -598,7 +598,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         }
 
         /// <inheritdoc />
-        public IEnumerable<HdAddress> GetUnusedAddresses(WalletAccountReference accountReference, int count, bool isChange = false)
+        public IEnumerable<HdAddress> GetUnusedAddresses(WalletAccountReference accountReference, int count, bool isChange = false, bool alwaysnew = false)
         {
             Guard.NotNull(accountReference, nameof(accountReference));
             Guard.Assert(count > 0);
@@ -607,6 +607,8 @@ namespace Stratis.Bitcoin.Features.Wallet
 
             bool generated = false;
             IEnumerable<HdAddress> addresses;
+            
+            var newAddresses = new List<HdAddress>();
 
             lock (this.lockObject)
             {
@@ -619,8 +621,8 @@ namespace Stratis.Bitcoin.Features.Wallet
                     account.InternalAddresses.Where(acc => !acc.Transactions.Any()).ToList() :
                     account.ExternalAddresses.Where(acc => !acc.Transactions.Any()).ToList();
 
-                int diff = unusedAddresses.Count - count;
-                var newAddresses = new List<HdAddress>();
+                int diff = alwaysnew ? -1 : unusedAddresses.Count - count;
+                
                 if (diff < 0)
                 {
                     newAddresses = account.CreateAddresses(this.network, Math.Abs(diff), isChange: isChange).ToList();
@@ -635,6 +637,8 @@ namespace Stratis.Bitcoin.Features.Wallet
             {
                 // Save the changes to the file.
                 this.SaveWallet(wallet);
+
+                return newAddresses;
             }
 
             return addresses;

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
@@ -245,11 +245,11 @@ namespace Stratis.Bitcoin.Features.Wallet
         {
             WalletAccountReference accountReference = this.GetWalletAccountReference();
             Wallet wallet = this.walletManager.GetWallet(accountReference.WalletName);
-            Block block = null;
+            ChainedHeaderBlock headerBlock = null;
 
             if (!string.IsNullOrEmpty(blockHash) && uint256.TryParse(blockHash, out uint256 hashBlock))
             {
-                this.ConsensusManager.GetOrDownloadBlocks(new List<uint256> { hashBlock }, b => { block = b.Block; });
+                this.ConsensusManager.GetOrDownloadBlocks(new List<uint256> { hashBlock }, b => { headerBlock = b; });
             }
 
             IEnumerable<TransactionData> transactions = wallet.GetAllTransactions();
@@ -262,7 +262,7 @@ namespace Stratis.Bitcoin.Features.Wallet
 
                 int blockHeight = transactionData.BlockHeight ?? 0;
 
-                if (block != null && blockHeight < this.ChainIndexer.GetHeader(block?.GetHash()).Height)
+                if (headerBlock?.ChainedHeader != null && blockHeight < headerBlock?.ChainedHeader.Height)
                     continue;
 
                 if (transaction.Confirmations < targetConfirmations)

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
@@ -245,11 +245,11 @@ namespace Stratis.Bitcoin.Features.Wallet
         {
             WalletAccountReference accountReference = this.GetWalletAccountReference();
             Wallet wallet = this.walletManager.GetWallet(accountReference.WalletName);
-            ChainedHeaderBlock headerBlock = null;
+            ChainedHeader headerBlock = null;
 
             if (!string.IsNullOrEmpty(blockHash) && uint256.TryParse(blockHash, out uint256 hashBlock))
             {
-                this.ConsensusManager.GetOrDownloadBlocks(new List<uint256> { hashBlock }, b => { headerBlock = b; });
+                headerBlock = this.ChainIndexer.GetHeader(hashBlock);
             }
 
             IEnumerable<TransactionData> transactions = wallet.GetAllTransactions();
@@ -262,7 +262,7 @@ namespace Stratis.Bitcoin.Features.Wallet
 
                 int blockHeight = transactionData.BlockHeight ?? 0;
 
-                if (headerBlock?.ChainedHeader != null && blockHeight < headerBlock?.ChainedHeader.Height)
+                if (headerBlock != null && blockHeight < headerBlock.Height)
                     continue;
 
                 if (transaction.Confirmations < targetConfirmations)

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
@@ -218,6 +218,32 @@ namespace Stratis.Bitcoin.Features.Wallet
         }
 
         /// <summary>
+        /// RPC method that gets the last unused address for receiving payments.
+        /// Uses the first wallet and account.
+        /// </summary>
+        /// <param name="account">Parameter is deprecated.</param>
+        /// <param name="addressType">Address type, currently only 'legacy' is supported.</param>
+        /// <returns>The new address.</returns>
+        [ActionName("getunusedaddress")]
+        [ActionDescription("Returns the last unused address for receiving payments.")]
+        public NewAddressModel GetUnusedAddress(string account, string addressType)
+        {
+            if (!string.IsNullOrEmpty(account))
+                throw new RPCServerException(RPCErrorCode.RPC_METHOD_DEPRECATED, "Use of 'account' parameter has been deprecated");
+
+            if (!string.IsNullOrEmpty(addressType))
+            {
+                // Currently segwit and bech32 addresses are not supported.
+                if (!addressType.Equals("legacy", StringComparison.InvariantCultureIgnoreCase))
+                    throw new RPCServerException(RPCErrorCode.RPC_METHOD_NOT_FOUND, "Only address type 'legacy' is currently supported.");
+            }
+            HdAddress hdAddress = this.walletManager.GetUnusedAddress(this.GetWalletAccountReference());
+            string base58Address = hdAddress.Address;
+
+            return new NewAddressModel(base58Address);
+        }
+
+        /// <summary>
         /// RPC method that returns the total available balance.
         /// The available balance is what the wallet considers currently spendable.
         ///

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
@@ -258,11 +258,11 @@ namespace Stratis.Bitcoin.Features.Wallet
 
             foreach (TransactionData transactionData in transactions)
             {
-                GetTransactionModel transaction = await this.GetTransactionAsync(transactionData.ToString());
+                GetTransactionModel transaction = await this.GetTransactionAsync(transactionData.Id.ToString());
 
                 int blockHeight = transactionData.BlockHeight ?? 0;
 
-                if (block != null && this.ChainIndexer.GetHeader(block?.GetHash()).Height < blockHeight)
+                if (block != null && blockHeight < this.ChainIndexer.GetHeader(block?.GetHash()).Height)
                     continue;
 
                 if (transaction.Confirmations < targetConfirmations)

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
@@ -290,7 +290,7 @@ namespace Stratis.Bitcoin.Features.Wallet
 
             foreach (TransactionData transactionData in transactions)
             {
-                GetTransactionModel transaction = await this.GetTransactionAsync(transactionData.Id.ToString());
+                GetTransactionModel transaction = this.GetTransaction(transactionData.Id.ToString());
 
                 int blockHeight = transactionData.BlockHeight ?? 0;
 

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
@@ -195,7 +195,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// <returns>The new address.</returns>
         [ActionName("getnewaddress")]
         [ActionDescription("Returns a new wallet address for receiving payments.")]
-        public NewAddressModel GetNewAddress(string account, string addressType)
+        public NewAddressModel GetNewAddress(string account = "", string addressType = "")
         {
             if (!string.IsNullOrEmpty(account))
                 throw new RPCServerException(RPCErrorCode.RPC_METHOD_DEPRECATED, "Use of 'account' parameter has been deprecated");
@@ -206,7 +206,12 @@ namespace Stratis.Bitcoin.Features.Wallet
                 if (!addressType.Equals("legacy", StringComparison.InvariantCultureIgnoreCase))
                     throw new RPCServerException(RPCErrorCode.RPC_METHOD_NOT_FOUND, "Only address type 'legacy' is currently supported.");
             }
-            HdAddress hdAddress = this.walletManager.GetUnusedAddress(this.GetWalletAccountReference());
+
+            WalletAccountReference accountReference = this.GetWalletAccountReference();
+            Wallet wallet = this.walletManager.GetWallet(accountReference.WalletName);
+            HdAccount walletAccount = wallet.GetAccount(accountReference.AccountName);
+            HdAddress hdAddress = walletAccount.CreateAddresses(this.Network, 1).Single();
+
             string base58Address = hdAddress.Address;
 
             return new NewAddressModel(base58Address);
@@ -232,6 +237,77 @@ namespace Stratis.Bitcoin.Features.Wallet
 
             Money balance = this.walletManager.GetSpendableTransactionsInAccount(account, minConfirmations).Sum(x => x.Transaction.Amount);
             return balance?.ToUnit(MoneyUnit.BTC) ?? 0;
+        }
+
+        [ActionName("listsinceblock")]
+        [ActionDescription("Get all transactions in blocks since block 'blockhash', or all transactions if omitted.")]
+        public async Task<ListSinceBlockModel> ListSinceBlockAsync(string blockHash, int targetConfirmations = 1)
+        {
+            WalletAccountReference accountReference = this.GetWalletAccountReference();
+            Wallet wallet = this.walletManager.GetWallet(accountReference.WalletName);
+            Block block = null;
+
+            if (!string.IsNullOrEmpty(blockHash) && uint256.TryParse(blockHash, out uint256 hashBlock))
+            {
+                this.ConsensusManager.GetOrDownloadBlocks(new List<uint256> { hashBlock }, b => { block = b.Block; });
+            }
+
+            IEnumerable<TransactionData> transactions = wallet.GetAllTransactions();
+
+            var model = new ListSinceBlockModel();
+
+            foreach (TransactionData transactionData in transactions)
+            {
+                GetTransactionModel transaction = await this.GetTransactionAsync(transactionData.ToString());
+
+                int blockHeight = transactionData.BlockHeight ?? 0;
+
+                if (block != null && this.ChainIndexer.GetHeader(block?.GetHash()).Height < blockHeight)
+                    continue;
+
+                if (transaction.Confirmations < targetConfirmations)
+                    continue;
+
+                foreach (GetTransactionDetailsModel transactionDetail in transaction.Details)
+                {
+                    ListSinceBlockTransactionCategoryModel category = GetListSinceBlockTransactionCategoryModel(transaction);
+
+                    model.Transactions.Add(new ListSinceBlockTransactionModel
+                    {
+                        Confirmations = transaction.Confirmations,
+                        BlockHash = transaction.BlockHash,
+                        BlockIndex = transaction.BlockIndex,
+                        BlockTime = transaction.BlockTime,
+                        TransactionId = transaction.TransactionId,
+                        TransactionTime = transaction.TransactionTime,
+                        TimeReceived = transaction.TimeReceived,
+                        Account = accountReference.AccountName,
+                        Address = transactionDetail.Address,
+                        Amount = transactionDetail.Amount,
+                        Category = category,
+                        Fee = transaction.Fee,
+                        OutputIndex = transactionDetail.OutputIndex
+                    });
+                }
+            }
+
+            model.LastBlock = this.ConsensusManager.Tip.HashBlock;
+
+            return model;
+        }
+
+        private ListSinceBlockTransactionCategoryModel GetListSinceBlockTransactionCategoryModel(GetTransactionModel transaction)
+        {
+            if (transaction.Isgenerated ?? false)
+            {
+                return transaction.Confirmations > this.FullNode.Network.Consensus.CoinbaseMaturity
+                    ? ListSinceBlockTransactionCategoryModel.Generate
+                    : ListSinceBlockTransactionCategoryModel.Immature;
+            }
+
+            return transaction.Amount > 0
+                ? ListSinceBlockTransactionCategoryModel.Receive
+                : ListSinceBlockTransactionCategoryModel.Send;
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
@@ -206,11 +206,10 @@ namespace Stratis.Bitcoin.Features.Wallet
                 if (!addressType.Equals("legacy", StringComparison.InvariantCultureIgnoreCase))
                     throw new RPCServerException(RPCErrorCode.RPC_METHOD_NOT_FOUND, "Only address type 'legacy' is currently supported.");
             }
-
+            
             WalletAccountReference accountReference = this.GetWalletAccountReference();
-            Wallet wallet = this.walletManager.GetWallet(accountReference.WalletName);
-            HdAccount walletAccount = wallet.GetAccount(accountReference.AccountName);
-            HdAddress hdAddress = walletAccount.CreateAddresses(this.Network, 1).Single();
+
+            HdAddress hdAddress = this.walletManager.GetUnusedAddresses(accountReference, 1, alwaysnew: true).Single();
 
             string base58Address = hdAddress.Address;
 

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
@@ -206,7 +206,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 if (!addressType.Equals("legacy", StringComparison.InvariantCultureIgnoreCase))
                     throw new RPCServerException(RPCErrorCode.RPC_METHOD_NOT_FOUND, "Only address type 'legacy' is currently supported.");
             }
-            
+
             WalletAccountReference accountReference = this.GetWalletAccountReference();
 
             HdAddress hdAddress = this.walletManager.GetUnusedAddresses(accountReference, 1, alwaysnew: true).Single();
@@ -268,14 +268,21 @@ namespace Stratis.Bitcoin.Features.Wallet
         [ActionDescription("Get all transactions in blocks since block 'blockhash', or all transactions if omitted.")]
         public async Task<ListSinceBlockModel> ListSinceBlockAsync(string blockHash, int targetConfirmations = 1)
         {
-            WalletAccountReference accountReference = this.GetWalletAccountReference();
-            Wallet wallet = this.walletManager.GetWallet(accountReference.WalletName);
             ChainedHeader headerBlock = null;
 
             if (!string.IsNullOrEmpty(blockHash) && uint256.TryParse(blockHash, out uint256 hashBlock))
             {
                 headerBlock = this.ChainIndexer.GetHeader(hashBlock);
             }
+
+            if (!string.IsNullOrEmpty(blockHash) && headerBlock == null)
+                throw new RPCServerException(RPCErrorCode.RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
+
+            if (targetConfirmations < 1)
+                throw new RPCServerException(RPCErrorCode.RPC_INVALID_PARAMETER, "Invalid parameter");
+
+            WalletAccountReference accountReference = this.GetWalletAccountReference();
+            Wallet wallet = this.walletManager.GetWallet(accountReference.WalletName);
 
             IEnumerable<TransactionData> transactions = wallet.GetAllTransactions();
 
@@ -293,27 +300,24 @@ namespace Stratis.Bitcoin.Features.Wallet
                 if (transaction.Confirmations < targetConfirmations)
                     continue;
 
-                foreach (GetTransactionDetailsModel transactionDetail in transaction.Details)
-                {
-                    ListSinceBlockTransactionCategoryModel category = GetListSinceBlockTransactionCategoryModel(transaction);
 
-                    model.Transactions.Add(new ListSinceBlockTransactionModel
-                    {
-                        Confirmations = transaction.Confirmations,
-                        BlockHash = transaction.BlockHash,
-                        BlockIndex = transaction.BlockIndex,
-                        BlockTime = transaction.BlockTime,
-                        TransactionId = transaction.TransactionId,
-                        TransactionTime = transaction.TransactionTime,
-                        TimeReceived = transaction.TimeReceived,
-                        Account = accountReference.AccountName,
-                        Address = transactionDetail.Address,
-                        Amount = transactionDetail.Amount,
-                        Category = category,
-                        Fee = transaction.Fee,
-                        OutputIndex = transactionDetail.OutputIndex
-                    });
-                }
+                ListSinceBlockTransactionCategoryModel category = GetListSinceBlockTransactionCategoryModel(transaction);
+
+                model.Transactions.Add(new ListSinceBlockTransactionModel
+                {
+                    Confirmations = transaction.Confirmations,
+                    BlockHash = transaction.BlockHash,
+                    BlockIndex = transaction.BlockIndex,
+                    BlockTime = transaction.BlockTime,
+                    TransactionId = transaction.TransactionId,
+                    TransactionTime = transaction.TransactionTime,
+                    TimeReceived = transaction.TimeReceived,
+                    Account = accountReference.AccountName,
+                    Address = transactionData.ScriptPubKey?.GetDestinationAddress(this.Network)?.ToString(),
+                    Amount = transaction.Amount,
+                    Category = category,
+                    Fee = transaction.Fee
+                });
             }
 
             model.LastBlock = this.ChainIndexer.Tip.HashBlock;

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
@@ -291,7 +291,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 }
             }
 
-            model.LastBlock = this.ConsensusManager.Tip.HashBlock;
+            model.LastBlock = this.ChainIndexer.Tip.HashBlock;
 
             return model;
         }

--- a/src/Stratis.Bitcoin.IntegrationTests/API/ApiSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/API/ApiSteps.cs
@@ -423,7 +423,7 @@ namespace Stratis.Bitcoin.IntegrationTests.API
         {
             var commands = JsonDataSerializer.Instance.Deserialize<List<RpcCommandModel>>(this.responseText);
 
-            commands.Count.Should().Be(30);
+            commands.Count.Should().Be(32);
             commands.Should().Contain(x => x.Command == "stop");
             commands.Should().Contain(x => x.Command == "getrawtransaction <txid> [<verbose>] [<blockhash>]");
             commands.Should().Contain(x => x.Command == "gettxout <txid> <vout> [<includemempool>]");
@@ -441,12 +441,14 @@ namespace Stratis.Bitcoin.IntegrationTests.API
             commands.Should().Contain(x => x.Command == "getstakinginfo [<isjsonformat>]");
             commands.Should().Contain(x => x.Command == "sendtoaddress <address> <amount> <commenttx> <commentdest>");
             commands.Should().Contain(x => x.Command == "getnewaddress <account> <addresstype>");
+            commands.Should().Contain(x => x.Command == "getunusedaddress <account> <addresstype>");
             commands.Should().Contain(x => x.Command == "sendrawtransaction <hex>");
             commands.Should().Contain(x => x.Command == "decoderawtransaction <hex>");
             commands.Should().Contain(x => x.Command == "getblock <blockhash> [<verbosity>]");
             commands.Should().Contain(x => x.Command == "walletlock");
             commands.Should().Contain(x => x.Command == "walletpassphrase <passphrase> <timeout>");
             commands.Should().Contain(x => x.Command == "listunspent [<minconfirmations>] [<maxconfirmations>] [<addressesjson>]");
+            commands.Should().Contain(x => x.Command == "listsinceblock <blockHash> [<targetConfirmations>]");
             commands.Should().Contain(x => x.Command == "sendmany <fromaccount> <addressesjson> [<minconf>] [<comment>] [<subtractfeefromjson>] [<isreplaceable>] [<conftarget>] [<estimatemode>]");
             commands.Should().Contain(x => x.Command == "getblockchaininfo");
             commands.Should().Contain(x => x.Command == "getnetworkinfo");


### PR DESCRIPTION
Added RPC methods:
- listsinceblock
- getunusedaddress

Changed RPC method:
- getnewaddress

Fixes a bug in the RPC middleware that causes a null reference exception when 'params' is not set in the request (work as with bitcoin)